### PR TITLE
Should “magisk“ in alpha.json is “app“?

### DIFF
--- a/alpha.json
+++ b/alpha.json
@@ -1,5 +1,5 @@
 {
-  "magisk": {
+  "app": {
     "version": "c609a01e-alpha",
     "versionCode": "21402",
     "link": "app-release.apk",


### PR DESCRIPTION
I think the word “magisk“ in alpha.json is “app“ because i cannot get the up-to-date magisk manager.[Maybe Lite and Alpha Magisk should update manager and then update magisk?]